### PR TITLE
Add Elements to data.json

### DIFF
--- a/data/data.json
+++ b/data/data.json
@@ -1642,8 +1642,7 @@
                 "45": {
                     "item": "heat",
                     "amount": 1,
-                    "type": "",
-                    "conditions": [
+                    "condition": [
                         "8",
                         ""
                     ]
@@ -2802,8 +2801,7 @@
                 "78": {
                     "item": "cold",
                     "amount": 1,
-                    "type": "",
-                    "conditions": [
+                    "condition": [
                         "16",
                         ""
                     ]
@@ -4448,8 +4446,7 @@
                 "86": {
                     "item": "wave",
                     "amount": 1,
-                    "type": "",
-                    "conditions": [
+                    "condition": [
                         "25",
                         ""
                     ]
@@ -4641,8 +4638,7 @@
                 "248": {
                     "item": "shock",
                     "amount": 1,
-                    "type": "",
-                    "conditions": [
+                    "condition": [
                         "27",
                         ""
                     ]

--- a/data/data.json
+++ b/data/data.json
@@ -1634,6 +1634,22 @@
             },
             "events": {}
         },
+        "cold-dng.b3.room7": {
+            "name": "Temple Mine - Chamber of Fire",
+            "chests": {},
+            "events": {},
+            "elements": {
+                "45": {
+                    "item": "heat",
+                    "amount": 1,
+                    "type": "",
+                    "conditions": [
+                        "8",
+                        ""
+                    ]
+                }
+            }
+        },
         "cold-dng.b4.center": {
             "name": "Temple Mine - Elevator",
             "chests": {
@@ -2777,6 +2793,22 @@
                 }
             },
             "events": {}
+        },
+        "heat-dng.f2.room-cold": {
+            "name": "Faj'ro Temple - Chamber of Ice",
+            "chests": {},
+            "events": {},
+            "elements": {
+                "78": {
+                    "item": "cold",
+                    "amount": 1,
+                    "type": "",
+                    "conditions": [
+                        "16",
+                        ""
+                    ]
+                }
+            }
         },
         "heat-dng.f3.room-02": {
             "name": "Faj'ro Temple - Bottom Chamber",
@@ -4408,6 +4440,22 @@
             },
             "events": {}
         },
+        "shock-dng.f2.room-element": {
+            "name": "Zir'vitar Temple - Chamber of Wave",
+            "chests": {},
+            "events": {},
+            "elements": {
+                "86": {
+                    "item": "wave",
+                    "amount": 1,
+                    "type": "",
+                    "conditions": [
+                        "25",
+                        ""
+                    ]
+                }
+            }
+        },
         "tree-dng.f3.branch-east": {
             "name": "Grand Krys'kajo - East Branch",
             "chests": {
@@ -4584,6 +4632,22 @@
                 }
             },
             "events": {}
+        },
+        "wave-dng.b1.center-05-element": {
+            "name": "So'najiz Temple - Chamber of Shock",
+            "chests": {},
+            "events": {},
+            "elements": {
+                "248": {
+                    "item": "shock",
+                    "amount": 1,
+                    "type": "",
+                    "conditions": [
+                        "27",
+                        ""
+                    ]
+                }
+            }
         },
         "wave-dng.b1.north-01": {
             "name": "So'najiz Temple - Moving Attraction",

--- a/src/checks.ts
+++ b/src/checks.ts
@@ -72,44 +72,7 @@ export async function getChecks(data: ItemData, options: GenerateOptions) {
 			.filter((c, i, arr) => arr.indexOf(c) === i);
 	}
 
-	const checks = [
-		{
-			type: 'element',
-			map: 'cold-dng.b3.room7',
-			mapName: 'Temple Mine - Chamber of Fire',
-			item: 'heat',
-			amount: 1,
-			mapId: 45,
-			conditions: [...areaConditions['8']],
-		},
-		{
-			type: 'element',
-			map: 'heat-dng.f2.room-cold',
-			mapName: 'Faj\'ro Temple - Chamber of Ice',
-			item: 'cold',
-			amount: 1,
-			mapId: 78,
-			conditions: [...areaConditions['16']],
-		},
-		{
-			type: 'element',
-			map: 'wave-dng.b1.center-05-element',
-			mapName: 'So\'najiz Temple - Chamber of Shock',
-			item: 'shock',
-			amount: 1,
-			mapId: 248,
-			conditions: [...areaConditions['27']],
-		},
-		{
-			type: 'element',
-			map: 'shock-dng.f2.room-element',
-			mapName: 'Zir\'vitar Temple - Chamber of Wave',
-			item: 'wave',
-			amount: 1,
-			mapId: 86,
-			conditions: [...areaConditions['25']],
-		},
-	] as Check[];
+	const checks = [];
 	for (const map of Object.keys(data.items)) {
 		for (const mapId of Object.keys(data.items[map].chests)) {
 			const { item, amount, type, condition } = data.items[map].chests[mapId];

--- a/src/checks.ts
+++ b/src/checks.ts
@@ -93,6 +93,14 @@ export async function getChecks(data: ItemData, options: GenerateOptions) {
 				checks.push({ type: 'event', map, mapName: data.items[map].name, mapId: Number(mapId), item, amount, path, conditions });
 			}
 		}
+		for (const mapId of Object.keys(data.items[map].elements ?? {})) {
+			const { item, amount, condition } = data.items[map].elements[mapId];
+			const conditions = (areaConditions[condition[0]] || ['softlock'])
+				.concat(condition.slice(1))
+				.filter(c => c)
+				.filter((c, i, arr) => arr.indexOf(c) === i);
+			checks.push({ type: 'element', map, mapName: data.items[map].name, mapId: Number(mapId), item, amount, conditions });
+		}
 	}
 
 	checks.sort((a, b) => {

--- a/src/item-data.model.ts
+++ b/src/item-data.model.ts
@@ -20,6 +20,7 @@ export interface RawMapItems {
 	name: string;
 	chests: RawChests;
 	events: RawEvents;
+	elements: RawElements;
 	disabledEvents: number[];
 	variablesOnLoad: Record<string, unknown>;
 }
@@ -39,6 +40,16 @@ export type RawEvents = { [mapId: string]: RawEvent[] };
 
 export interface RawEvent {
 	item: number;
+	amount: number;
+	type: '';
+	condition: [area: string, ...conditions: string[]];
+	path: string;
+}
+
+export type RawElements = { [mapId: string]: RawElement };
+
+export interface RawElement {
+	item: string;
 	amount: number;
 	type: '';
 	condition: [area: string, ...conditions: string[]];


### PR DESCRIPTION
This pull request adds the elements to `data.json` as opposed to having them hardcoded.

I did minimal testing by introspecting a newly generated `randomizerState.json`. My findings were:
* All map locations where `.item` is an element are present.
* All map locations where `.replacedWith.item` is an element are present.

I'm pretty comfortable saying this works.